### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete multi-character sanitization

### DIFF
--- a/src/components/notes/NoteCard.jsx
+++ b/src/components/notes/NoteCard.jsx
@@ -75,11 +75,22 @@ const NoteCard = ({ note, onEdit, onDelete }) => {
     });
   };
 
+  // Helper to robustly strip HTML tags (handles nested or repeated tags)
+  const stripHtmlTags = (input) => {
+    if (!input) return '';
+    let prev;
+    do {
+      prev = input;
+      input = input.replace(/<[^>]*>/g, '');
+    } while (input !== prev);
+    return input;
+  };
+
   const getContentPreview = (content) => {
     if (!content) return 'No content';
     
     // Strip HTML tags for preview
-    const textContent = content.replace(/<[^>]*>/g, '');
+    const textContent = stripHtmlTags(content);
     return textContent.length > 150 
       ? textContent.substring(0, 150) + '...' 
       : textContent;
@@ -105,7 +116,7 @@ const NoteCard = ({ note, onEdit, onDelete }) => {
 
   const getWordCount = (content) => {
     if (!content) return 0;
-    const textContent = content.replace(/<[^>]*>/g, '');
+    const textContent = stripHtmlTags(content);
     return textContent.trim().split(/\s+/).filter(word => word.length > 0).length;
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/know120/know120.github.io/security/code-scanning/5](https://github.com/know120/know120.github.io/security/code-scanning/5)

**How to fix the problem:**  
For robust and reliable sanitization, use a well-maintained library such as `sanitize-html` that is specifically designed to remove (or whitelist) HTML tags and prevent cross-site scripting vulnerabilities. If the use of external libraries is not permitted or wanted, then at least re-apply the regular expression in a loop until no more replacements are found, ensuring that all nested or consecutive tags are removed.

**Detailed description of the single best way to fix it:**  
The most reliable method, with no change to existing functionality, is to use the `sanitize-html` npm library. However, if we cannot assume adding new dependencies is appropriate and must stick to the current design, the next best is to repeatedly apply the regular expression replace on the content string until it no longer changes. This guarantees all HTML tags, including any revealed after one removal, are eliminated.

**Where to change:**  
All instances of `content.replace(/<[^>]*>/g, '')` in `NoteCard.jsx` should be replaced with a helper function that repeatedly removes HTML tags until none remain. This occurs in `getContentPreview` (line 82) and `getWordCount` (line 108).

**What is needed:**  
- A local function to perform safe tag stripping, such as `stripHtmlTags(input)`.
- Replace instances of `content.replace(/<[^>]*>/g, '')` with `stripHtmlTags(content)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
