### PR TITLE
Potential fix for code scanning alert no. 6: Clear text storage of sensitive information

### DIFF
--- a/src/pages/TokenUsage.jsx
+++ b/src/pages/TokenUsage.jsx
@@ -14,25 +14,21 @@ const TokenUsage = () => {
   const [showApiKey, setShowApiKey] = useState(false);
 
   useEffect(() => {
-    const savedApiKey = localStorage.getItem('tokenUsage_apiKey');
     const savedProvider = localStorage.getItem('tokenUsage_provider');
 
-    if (savedApiKey || savedProvider) {
+    if (savedProvider) {
       setFormData(prev => ({
-        apiKey: savedApiKey || '',
+        apiKey: '',
         provider: savedProvider || 'openai'
       }));
     }
   }, []);
 
   useEffect(() => {
-    if (formData.apiKey) {
-      localStorage.setItem('tokenUsage_apiKey', formData.apiKey);
-    }
     if (formData.provider) {
       localStorage.setItem('tokenUsage_provider', formData.provider);
     }
-  }, [formData]);
+  }, [formData.provider]);
 
   const validateForm = () => {
     const newErrors = {};


### PR DESCRIPTION
Potential fix for [https://github.com/know120/know120.github.io/security/code-scanning/6](https://github.com/know120/know120.github.io/security/code-scanning/6)

General fix: do not store sensitive secrets (API keys) in cleartext browser storage (`localStorage`, cookies, sessionStorage). For client apps, the safest approach is to avoid persistence entirely and keep secrets only in transient component state.

Best fix here (without changing core functionality of token checking):  
- In `src/pages/TokenUsage.jsx`, stop reading `tokenUsage_apiKey` from `localStorage` in the initial `useEffect`.  
- Stop writing `formData.apiKey` to `localStorage` in the persistence `useEffect`.  
- Continue persisting only `provider` (non-sensitive), and initialize `apiKey` as empty string.

This single change addresses all alert variants because they all originate from the same cleartext read/write flow involving `savedApiKey` and `formData.apiKey`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
